### PR TITLE
Queuing of new masternodes updated

### DIFF
--- a/src/masternode.h
+++ b/src/masternode.h
@@ -254,7 +254,7 @@ public:
         sigTime = 0;
         lastPing = CMasternodePing();
         wins = 0;
-        prevCycleLastPaymentTime = 0;
+        prevCycleLastPaymentTime = GetAdjustedTime();
     }
 
     bool IsEnabled()

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -114,6 +114,8 @@ public:
 	
     int CountMillionsLocked(int protocolVersion = -1);
 
+    int CountMillionsLockedLaunch(int protocolVersion, int64_t sigTime);
+
     void CountNetworks(int protocolVersion, int& ipv4, int& ipv6, int& onion);
 
     void DsegUpdate(CNode* pnode);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -215,6 +215,7 @@ UniValue listmasternodes(const UniValue& params, bool fHelp)
             "    \"lastseen\": ttt,     (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the last seen\n"
             "    \"activetime\": ttt,   (numeric) The time in seconds since epoch (Jan 1 1970 GMT) masternode has been active\n"
             "    \"lastpaid\": ttt,     (numeric) The time in seconds since epoch (Jan 1 1970 GMT) masternode was last paid\n"
+            "    \"seconds since payment\": ttt (numeric) The time in seconds since Jan 1 1970 seconds since the first reward of the masternode last cycle\n"
             "  }\n"
             "  ,...\n"
             "]\n"
@@ -267,6 +268,7 @@ UniValue listmasternodes(const UniValue& params, bool fHelp)
             obj.push_back(Pair("lastseen", (int64_t)mn->lastPing.sigTime));
             obj.push_back(Pair("activetime", (int64_t)(mn->lastPing.sigTime - mn->sigTime)));
             obj.push_back(Pair("lastpaid", (int64_t)mn->GetLastPaid()));
+            obj.push_back(Pair("secondsSincePayment", mn->SecondsSincePayment()));
 
             ret.push_back(obj);
         }


### PR DESCRIPTION
Instead of waiting until as many blocks are processed as there are millions locked in total, new / freshly connected masternodes only wait for as many blocks as there are masternodes older
than them (they no longer wait longer than needed if more new masternodes connect)