### PR TITLE
[Bug] Prevent Over-payment of Masternodes

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -610,7 +610,7 @@ bool CMasternodeBlockPayees::IsTransactionValid(const CTransaction& txNew)
         bool found = false;
         BOOST_FOREACH (CTxOut out, txNew.vout) {
             if (payee.scriptPubKey == out.scriptPubKey) {
-                if(out.nValue >= requiredMasternodePayment)
+                if(out.nValue == requiredMasternodePayment)
                     found = true;
                 else
                     LogPrint("masternode","Masternode payment is out of drift range. Paid=%s Min=%s\n", FormatMoney(out.nValue).c_str(), FormatMoney(requiredMasternodePayment).c_str());


### PR DESCRIPTION
This code pertains to a legacy block reward schedule allowing for an over-payment to Masternodes based on a PIVX See-Saw reward structure.
Since it is not used here where the payment can change/fluctuate we need more strict checks on the masternode payment to be the required value no different.
Also fixes any possible exploitation of this to get larger Masternode rewards.